### PR TITLE
Changes on Alerting Endpoints component naming.

### DIFF
--- a/pkg/config/alertidcfg.go
+++ b/pkg/config/alertidcfg.go
@@ -25,7 +25,7 @@ func (dbc *DatabaseCfg) GetAlertIDCfgByID(id string) (AlertIDCfg, error) {
 		return AlertIDCfg{}, fmt.Errorf("Error %d results on get AlertIDCfgArray by id %s", len(cfgarray), id)
 	}
 	if len(cfgarray) == 0 {
-		return AlertIDCfg{}, fmt.Errorf("Error no values have been returned with this id %s in the influx config table", id)
+		return AlertIDCfg{}, fmt.Errorf("Error no values have been returned with this id %s in the config table", id)
 	}
 	return *cfgarray[0], nil
 }
@@ -48,20 +48,20 @@ func (dbc *DatabaseCfg) GetAlertIDCfgArray(filter string) ([]*AlertIDCfg, error)
 	//Get Only data for selected devices
 	if len(filter) > 0 {
 		if err = dbc.x.Where(filter).Find(&devices); err != nil {
-			log.Warnf("Fail to get AlertIDCfg  data filteter with %s : %v\n", filter, err)
+			log.Warnf("Fail to get AlertIDCfg data filtered with %s : %v\n", filter, err)
 			return nil, err
 		}
 	} else {
 		if err = dbc.x.Find(&devices); err != nil {
-			log.Warnf("Fail to get influxcfg   data: %v\n", err)
+			log.Warnf("Fail to get AlertIDCfg data: %v\n", err)
 			return nil, err
 		}
 	}
 
-	//Asign HTTP Outs to AlertID's
-	var alerthttp []*AlertHTTPOutRel
+	//Asign Endpoints to AlertID's
+	var alerthttp []*AlertEndpointRel
 	if err = dbc.x.Find(&alerthttp); err != nil {
-		log.Warnf("Fail to get Output Alert and its HTTP output relationship data: %v\n", err)
+		log.Warnf("Fail to get AlertIDCfg and its Endpoint relationship data: %v\n", err)
 		return devices, err
 	}
 
@@ -70,7 +70,7 @@ func (dbc *DatabaseCfg) GetAlertIDCfgArray(filter string) ([]*AlertIDCfg, error)
 	for _, v := range devices {
 		for _, r := range alerthttp {
 			if r.AlertID == v.ID {
-				v.OutHTTP = append(v.OutHTTP, r.HTTPOutID)
+				v.Endpoint = append(v.Endpoint, r.EndpointID)
 			}
 		}
 	}
@@ -90,12 +90,12 @@ func (dbc *DatabaseCfg) AddAlertIDCfg(dev *AlertIDCfg) (int64, error) {
 		session.Rollback()
 		return 0, err
 	}
-	//save new alert ot outhttp relations
-	for _, o := range dev.OutHTTP {
+	//save new alert endpoint relations
+	for _, o := range dev.Endpoint {
 
-		ostruct := AlertHTTPOutRel{
-			AlertID:   dev.ID,
-			HTTPOutID: o,
+		ostruct := AlertEndpointRel{
+			AlertID:    dev.ID,
+			EndpointID: o,
 		}
 		newo, err = session.Insert(&ostruct)
 		if err != nil {
@@ -109,30 +109,24 @@ func (dbc *DatabaseCfg) AddAlertIDCfg(dev *AlertIDCfg) (int64, error) {
 	if err != nil {
 		return 0, err
 	}
-	log.Infof("Added new Alert ID Successfully with id %s [ %d HTTP Output] ", dev.ID, newo)
+	log.Infof("Added new Alert ID Successfully with id %s [ %d Endpoint] ", dev.ID, newo)
 	dbc.addChanges(affected)
 	return affected, nil
 }
 
-/*DelAlertIDCfg for deleting influx databases from ID*/
+/*DelAlertIDCfg for deleting alerts from ID*/
 func (dbc *DatabaseCfg) DelAlertIDCfg(id string) (int64, error) {
-	var affecteddev, affectedouts, affected int64
+	var affectedouts, affected int64
 	var err error
 
 	session := dbc.x.NewSession()
 	defer session.Close()
 
-	affecteddev, err = session.Where("kapacitorid='" + id + "'").Cols("kapacitorid").Update(&AlertIDCfg{})
+	//first deleting references in AlertEndpointRel
+	affectedouts, err = session.Where("alert_id='" + id + "'").Delete(&AlertEndpointRel{})
 	if err != nil {
 		session.Rollback()
-		return 0, fmt.Errorf("Error on Delete Alert with id on delete AlertIDCfg with id: %s, error: %s", id, err)
-	}
-
-	//first deleting references in AlertHTTPOutRel
-	affectedouts, err = session.Where("alert_id='" + id + "'").Delete(&AlertHTTPOutRel{})
-	if err != nil {
-		session.Rollback()
-		return 0, fmt.Errorf("Error on Delete Device with id on delete AlertHTTPOutRel with id: %s, error: %s", id, err)
+		return 0, fmt.Errorf("Error on delete AlertEndpointRel with id: %s, error: %s", id, err)
 	}
 
 	affected, err = session.Where("id='" + id + "'").Delete(&AlertIDCfg{})
@@ -145,29 +139,29 @@ func (dbc *DatabaseCfg) DelAlertIDCfg(id string) (int64, error) {
 	if err != nil {
 		return 0, err
 	}
-	log.Infof("Deleted Successfully Alert with ID %s [ %d Affected alerts   ] [%d affected Outs]", id, affecteddev, affectedouts)
-	dbc.addChanges(affected + affecteddev + affectedouts)
+	log.Infof("Deleted Successfully Alert with ID %s [ %d Affected alerts   ] [%d affected endpoints]", id, affected, affectedouts)
+	dbc.addChanges(affected + affectedouts)
 	return affected, nil
 }
 
-/*UpdateAlertIDCfg for adding new influxdb*/
+/*UpdateAlertIDCfg for updating AlertIDCfg*/
 func (dbc *DatabaseCfg) UpdateAlertIDCfg(id string, dev *AlertIDCfg) (int64, error) {
-	var affecteddev, affected int64
+	var affected int64
 	var err error
 	session := dbc.x.NewSession()
 	defer session.Close()
-	//first deleting references in AlertHTTPOutRel
-	_, err = session.Where("alert_id='" + id + "'").Delete(&AlertHTTPOutRel{})
+	//first deleting references in AlertEndpointRel
+	_, err = session.Where("alert_id='" + id + "'").Delete(&AlertEndpointRel{})
 	if err != nil {
 		session.Rollback()
-		return 0, fmt.Errorf("Error on Delete Device with id on delete AlertHTTPOutRel with id: %s, error: %s", id, err)
+		return 0, fmt.Errorf("Error on delete AlertEndpointRel with id: %s, error: %s", id, err)
 	}
-	//save again aññ alert ot outhttp relations
-	for _, o := range dev.OutHTTP {
+	//save again alert endpoint relations
+	for _, o := range dev.Endpoint {
 
-		ostruct := AlertHTTPOutRel{
-			AlertID:   dev.ID,
-			HTTPOutID: o,
+		ostruct := AlertEndpointRel{
+			AlertID:    dev.ID,
+			EndpointID: o,
 		}
 		_, err = session.Insert(&ostruct)
 		if err != nil {
@@ -186,12 +180,12 @@ func (dbc *DatabaseCfg) UpdateAlertIDCfg(id string, dev *AlertIDCfg) (int64, err
 		return 0, err
 	}
 
-	log.Infof("Updated Alert ID Config Successfully with id %s and data:%+v, affected", id, dev)
-	dbc.addChanges(affected + affecteddev)
+	log.Infof("Updated Alert ID Config Successfully with id %s and data:%+v, %d affected", id, dev, affected)
+	dbc.addChanges(affected)
 	return affected, nil
 }
 
-/*GetAlertIDCfgAffectOnDel for deleting devices from ID*/
+/*GetAlertIDCfgAffectOnDel NO config tables affected when deleting AlertIDCfg */
 func (dbc *DatabaseCfg) GetAlertIDCfgAffectOnDel(id string) ([]*DbObjAction, error) {
 	//var devices []*AlertIDCfg
 	var obj []*DbObjAction

--- a/pkg/config/database.go
+++ b/pkg/config/database.go
@@ -107,11 +107,11 @@ func (dbc *DatabaseCfg) InitDB() {
 	if err = dbc.x.Sync(new(RangeTimeCfg)); err != nil {
 		log.Fatalf("Fail to sync database RangeTimeCfg: %v\n", err)
 	}
-	if err = dbc.x.Sync(new(OutHTTPCfg)); err != nil {
-		log.Fatalf("Fail to sync database OutHTTPOuts: %v\n", err)
+	if err = dbc.x.Sync(new(EndpointCfg)); err != nil {
+		log.Fatalf("Fail to sync database Endpoints: %v\n", err)
 	}
-	if err = dbc.x.Sync(new(AlertHTTPOutRel)); err != nil {
-		log.Fatalf("Fail to sync database Alert and HTTPOut Relationship: %v\n", err)
+	if err = dbc.x.Sync(new(AlertEndpointRel)); err != nil {
+		log.Fatalf("Fail to sync database Alert and Endpoint Relationship: %v\n", err)
 	}
 	if err = dbc.x.Sync(new(AlertIDCfg)); err != nil {
 		log.Fatalf("Fail to sync database AlertIDCfg: %v\n", err)
@@ -130,9 +130,9 @@ func (dbc *DatabaseCfg) LoadDbConfig(cfg *DBConfig) {
 	if err != nil {
 		log.Warningf("Some errors on get Kapacitor servers map :%v", err)
 	}
-	cfg.OutHTTP, err = dbc.GetOutHTTPCfgMap("")
+	cfg.Endpoint, err = dbc.GetEndpointCfgMap("")
 	if err != nil {
-		log.Warningf("Some errors on get Out HTTP map :%v", err)
+		log.Warningf("Some errors on get Endpoint map :%v", err)
 	}
 	cfg.RangeTime, err = dbc.GetRangeTimeCfgMap("")
 	if err != nil {

--- a/pkg/config/dbconfig.go
+++ b/pkg/config/dbconfig.go
@@ -133,8 +133,8 @@ type TemplateCfg struct {
 	ServersWOLastDeployment []string  `xorm:"servers_wo_last_deployment"`
 }
 
-// OutHTTPCfg Alert Destination HTTP based backends config
-type OutHTTPCfg struct {
+// EndpointCfg Alert Destination HTTP based backends config
+type EndpointCfg struct {
 	ID                 string   `xorm:"'id' unique" binding:"Required"`
 	Type               string   `xorm:"type"`
 	Description        string   `xorm:"description"`
@@ -155,19 +155,19 @@ type OutHTTPCfg struct {
 }
 
 // TableName go-xorm way to set the Table name to something different to "alert_h_t_t_p_out_rel"
-func (OutHTTPCfg) TableName() string {
-	return "out_http_cfg"
+func (EndpointCfg) TableName() string {
+	return "endpoint_cfg"
 }
 
-// AlertHTTPOutRel  relation between Alerts and HTTP Out's type
-type AlertHTTPOutRel struct {
-	AlertID   string `xorm:"alert_id"`
-	HTTPOutID string `xorm:"http_out_id"`
+// AlertEndpointRel  relation between Alerts and Endpoint's type
+type AlertEndpointRel struct {
+	AlertID    string `xorm:"alert_id"`
+	EndpointID string `xorm:"endpoint_id"`
 }
 
 // TableName go-xorm way to set the Table name to something different to "alert_h_t_t_p_out_rel"
-func (AlertHTTPOutRel) TableName() string {
-	return "alert_http_out_rel"
+func (AlertEndpointRel) TableName() string {
+	return "alert_endpoint_rel"
 }
 
 // AlertIDCfg Alert Definition Config type
@@ -229,7 +229,7 @@ type AlertIDCfg struct {
 	//Where to deploy this rule
 	KapacitorID string `xorm:"kapacitorid" binding:"Required"`
 
-	OutHTTP                 []string  `xorm:"-"` //relation with outhttpcfgs
+	Endpoint                []string  `xorm:"-"` //relation with endpointcfgs
 	Modified                time.Time `xorm:"modified"`
 	ServersWOLastDeployment []string  `xorm:"servers_wo_last_deployment"`
 }
@@ -272,7 +272,7 @@ type DBConfig struct {
 	AlertID    map[string]*AlertIDCfg
 	AlertEvent map[int64]*AlertEventHist
 	Template   map[string]*TemplateCfg
-	OutHTTP    map[string]*OutHTTPCfg
+	Endpoint   map[string]*EndpointCfg
 }
 
 // Init initialices the DB

--- a/pkg/config/endpointcfg.go
+++ b/pkg/config/endpointcfg.go
@@ -1,0 +1,163 @@
+package config
+
+import (
+	"fmt"
+)
+
+/***************************
+	EndpointCfg DB backends
+	-GetEndpointCfgCfgByID(struct)
+	-GetEndpointCfgMap (map - for interna config use
+	-GetEndpointCfgArray(Array - for web ui use )
+	-AddEndpointCfg
+	-DelEndpointCfg
+	-UpdateEndpointCfg
+  -GetEndpointCfgAffectOnDel
+***********************************/
+
+/*GetEndpointCfgByID get device data by id*/
+func (dbc *DatabaseCfg) GetEndpointCfgByID(id string) (EndpointCfg, error) {
+	cfgarray, err := dbc.GetEndpointCfgArray("id='" + id + "'")
+	if err != nil {
+		return EndpointCfg{}, err
+	}
+	if len(cfgarray) > 1 {
+		return EndpointCfg{}, fmt.Errorf("Error %d results on get EndpointCfg by id %s", len(cfgarray), id)
+	}
+	if len(cfgarray) == 0 {
+		return EndpointCfg{}, fmt.Errorf("Error no values have been returned with this id %s in the influx config table", id)
+	}
+	return *cfgarray[0], nil
+}
+
+/*GetEndpointCfgMap  return data in map format*/
+func (dbc *DatabaseCfg) GetEndpointCfgMap(filter string) (map[string]*EndpointCfg, error) {
+	cfgarray, err := dbc.GetEndpointCfgArray(filter)
+	cfgmap := make(map[string]*EndpointCfg)
+	for _, val := range cfgarray {
+		cfgmap[val.ID] = val
+		log.Debugf("%+v", *val)
+	}
+	return cfgmap, err
+}
+
+/*GetEndpointCfgArray generate an array of devices with all its information */
+func (dbc *DatabaseCfg) GetEndpointCfgArray(filter string) ([]*EndpointCfg, error) {
+	var err error
+	var devices []*EndpointCfg
+	//Get Only data for selected devices
+	if len(filter) > 0 {
+		if err = dbc.x.Where(filter).Find(&devices); err != nil {
+			log.Warnf("Fail to get EndpointCfg  data filteter with %s : %v\n", filter, err)
+			return nil, err
+		}
+	} else {
+		if err = dbc.x.Find(&devices); err != nil {
+			log.Warnf("Fail to get influxcfg   data: %v\n", err)
+			return nil, err
+		}
+	}
+	return devices, nil
+}
+
+/*AddEndpointCfg for adding new devices*/
+func (dbc *DatabaseCfg) AddEndpointCfg(dev *EndpointCfg) (int64, error) {
+	var err error
+	var affected int64
+	session := dbc.x.NewSession()
+	defer session.Close()
+
+	affected, err = session.Insert(dev)
+	if err != nil {
+		session.Rollback()
+		return 0, err
+	}
+	//no other relation
+	err = session.Commit()
+	if err != nil {
+		return 0, err
+	}
+	log.Infof("Added new  Endpoint backend Successfully with id %s ", dev.ID)
+	dbc.addChanges(affected)
+	return affected, nil
+}
+
+/*DelEndpointCfg for deleting influx databases from ID*/
+func (dbc *DatabaseCfg) DelEndpointCfg(id string) (int64, error) {
+	var affecteddev, affected int64
+	var err error
+
+	session := dbc.x.NewSession()
+	defer session.Close()
+
+	affecteddev, err = session.Where("kapacitorid='" + id + "'").Cols("kapacitorid").Update(&AlertIDCfg{})
+	if err != nil {
+		session.Rollback()
+		return 0, fmt.Errorf("Error on Delete EndpointCfg with id: %s, error: %s", id, err)
+	}
+
+	affected, err = session.Where("id='" + id + "'").Delete(&EndpointCfg{})
+	if err != nil {
+		session.Rollback()
+		return 0, err
+	}
+
+	err = session.Commit()
+	if err != nil {
+		return 0, err
+	}
+	log.Infof("Deleted Successfully Endpoint with ID %s [ %d Devices Affected  ]", id, affecteddev)
+	dbc.addChanges(affected + affecteddev)
+	return affected, nil
+}
+
+/*UpdateEndpointCfg for adding new influxdb*/
+func (dbc *DatabaseCfg) UpdateEndpointCfg(id string, dev *EndpointCfg) (int64, error) {
+	var affecteddev, affected int64
+	var err error
+	session := dbc.x.NewSession()
+	defer session.Close()
+	if id != dev.ID { //ID has been changed
+		affecteddev, err = session.Where("kapacitorid='" + id + "'").Cols("kapacitorid").Update(&AlertIDCfg{KapacitorID: dev.ID})
+		if err != nil {
+			session.Rollback()
+			return 0, fmt.Errorf("Error on Update InfluxConfig on update id(old)  %s with (new): %s, error: %s", id, dev.ID, err)
+		}
+		log.Infof("Updated Influx Config to %s devices ", affecteddev)
+	}
+
+	affected, err = session.Where("id='" + id + "'").UseBool().AllCols().Update(dev)
+	if err != nil {
+		session.Rollback()
+		return 0, err
+	}
+	err = session.Commit()
+	if err != nil {
+		return 0, err
+	}
+
+	log.Infof("Updated Endpoint Successfully with id %s and data:%+v, affected", id, dev)
+	dbc.addChanges(affected + affecteddev)
+	return affected, nil
+}
+
+/*GetEndpointCfgAffectOnDel for deleting devices from ID*/
+func (dbc *DatabaseCfg) GetEndpointCfgAffectOnDel(id string) ([]*DbObjAction, error) {
+	var devices []*AlertEndpointRel
+	var obj []*DbObjAction
+	if err := dbc.x.Where("endpoint_id='" + id + "'").Find(&devices); err != nil {
+		log.Warnf("Error on Get Out Endpoint id %d for devices , error: %s", id, err)
+		return nil, err
+	}
+
+	for _, val := range devices {
+		obj = append(obj, &DbObjAction{
+			Type:     "alertidcfg",
+			TypeDesc: "alertID's ",
+			ObID:     val.AlertID,
+			Action:   "Change alert to Other Kapacitor alert",
+		})
+
+	}
+	return obj, nil
+}

--- a/pkg/data/impexp/exportdata.go
+++ b/pkg/data/impexp/exportdata.go
@@ -149,12 +149,12 @@ func (e *ExportData) Export(ObjType string, id string, recursive bool, level int
 		for _, val := range v.Products {
 			e.Export("productcfg", val, recursive, level+1)
 		}
-	case "outhttpcfg":
-		v, err := dbc.GetOutHTTPCfgByID(id)
+	case "endpointcfg":
+		v, err := dbc.GetEndpointCfgByID(id)
 		if err != nil {
 			return err
 		}
-		e.PrependObject(&ExportObject{ObjectTypeID: "outhttpcfg", ObjectID: id, ObjectCfg: v})
+		e.PrependObject(&ExportObject{ObjectTypeID: "endpointcfg", ObjectID: id, ObjectCfg: v})
 	case "alertcfg":
 		//contains sensible data
 		v, err := dbc.GetAlertIDCfgByID(id)
@@ -165,8 +165,8 @@ func (e *ExportData) Export(ObjType string, id string, recursive bool, level int
 		if !recursive {
 			break
 		}
-		for _, val := range v.OutHTTP {
-			e.Export("outhttpcfg", val, recursive, level+1)
+		for _, val := range v.Endpoint {
+			e.Export("endpointcfg", val, recursive, level+1)
 		}
 		e.Export("kapacitorcfg", v.KapacitorID, recursive, level+1)
 		e.Export("productcfg", v.ProductID, recursive, level+1)

--- a/pkg/data/impexp/import.go
+++ b/pkg/data/impexp/import.go
@@ -126,8 +126,8 @@ func (e *ExportData) ImportCheck() (*ExportData, error) {
 				o.Error = fmt.Sprintf("Duplicated object %s in the database", o.ObjectID)
 				duplicated = append(duplicated, o)
 			}
-		case "outhttpcfg":
-			data := config.OutHTTPCfg{}
+		case "endpointcfg":
+			data := config.EndpointCfg{}
 			json.Unmarshal(raw, &data)
 			ers := binding.RawValidate(data)
 			if ers.Len() > 0 {
@@ -136,7 +136,7 @@ func (e *ExportData) ImportCheck() (*ExportData, error) {
 				duplicated = append(duplicated, o)
 				break
 			}
-			_, err := dbc.GetOutHTTPCfgByID(o.ObjectID)
+			_, err := dbc.GetEndpointCfgByID(o.ObjectID)
 			if err == nil {
 				o.Error = fmt.Sprintf("Duplicated object %s in the database", o.ObjectID)
 				duplicated = append(duplicated, o)
@@ -317,15 +317,15 @@ func (e *ExportData) Import(overwrite bool, autorename bool) error {
 			if err != nil {
 				return err
 			}
-		case "outhttpcfg":
-			log.Debugf("Importing outhttpcfg : %+v", o.ObjectCfg)
-			data := config.OutHTTPCfg{}
+		case "endpointcfg":
+			log.Debugf("Importing endpointcfg : %+v", o.ObjectCfg)
+			data := config.EndpointCfg{}
 			json.Unmarshal(raw, &data)
 			var err error
-			_, err = dbc.GetOutHTTPCfgByID(o.ObjectID)
+			_, err = dbc.GetEndpointCfgByID(o.ObjectID)
 			if err == nil { //value exist already in the database
 				if overwrite == true {
-					_, err2 := dbc.UpdateOutHTTPCfg(o.ObjectID, &data)
+					_, err2 := dbc.UpdateEndpointCfg(o.ObjectID, &data)
 					if err2 != nil {
 						return fmt.Errorf("Error on overwrite object [%s] %s : %s", o.ObjectTypeID, o.ObjectID, err2)
 					}
@@ -335,7 +335,7 @@ func (e *ExportData) Import(overwrite bool, autorename bool) error {
 			if autorename == true {
 				data.ID = data.ID + suffix
 			}
-			_, err = dbc.AddOutHTTPCfg(&data)
+			_, err = dbc.AddEndpointCfg(&data)
 			if err != nil {
 				return err
 			}

--- a/pkg/kapa/kapa-utils.go
+++ b/pkg/kapa/kapa-utils.go
@@ -610,8 +610,8 @@ func setKapaTaskVars(dev config.AlertIDCfg) kapacitorClient.Vars {
 	vars["ID_NUMALERT"] = kapacitorClient.Var{Type: kapacitorClient.VarInt, Value: dev.NumAlertID}
 	vars["ID_INSTRUCTION"] = kapacitorClient.Var{Type: kapacitorClient.VarString, Value: dev.OperationID}
 	//External Services Settings
-	//OutHTTP
-	vars["OUT_HTTP"] = kapacitorClient.Var{Type: kapacitorClient.VarString, Value: strings.Join(dev.OutHTTP, ",")}
+	//Endpoint
+	vars["OUT_HTTP"] = kapacitorClient.Var{Type: kapacitorClient.VarString, Value: strings.Join(dev.Endpoint, ",")}
 	//KapacitorID
 	//Data Origin Settings
 	vars["INFLUX_BD"] = kapacitorClient.Var{Type: kapacitorClient.VarString, Value: getIfxDBNameByID(dev.InfluxDB)}

--- a/pkg/webui/apicfg-endpoint.go
+++ b/pkg/webui/apicfg-endpoint.go
@@ -1,0 +1,102 @@
+package webui
+
+import (
+	"github.com/go-macaron/binding"
+	"github.com/toni-moreno/resistor/pkg/agent"
+	"github.com/toni-moreno/resistor/pkg/config"
+	"gopkg.in/macaron.v1"
+)
+
+// NewAPICfgEndpoint create new API
+func NewAPICfgEndpoint(m *macaron.Macaron) error {
+
+	bind := binding.Bind
+
+	// Data sources
+	m.Group("/api/cfg/endpoint", func() {
+		m.Get("/", reqSignedIn, GetEndpoint)
+		m.Post("/", reqSignedIn, bind(config.EndpointCfg{}), AddEndpoint)
+		m.Put("/:id", reqSignedIn, bind(config.EndpointCfg{}), UpdateEndpoint)
+		m.Delete("/:id", reqSignedIn, DeleteEndpoint)
+		m.Get("/:id", reqSignedIn, GetEndpointCfgByID)
+		m.Get("/checkondel/:id", reqSignedIn, GetEndpointAffectOnDel)
+	})
+
+	return nil
+}
+
+// GetEndpoint Return snmpdevice list to frontend
+func GetEndpoint(ctx *Context) {
+	devcfgarray, err := agent.MainConfig.Database.GetEndpointCfgArray("")
+	if err != nil {
+		ctx.JSON(404, err.Error())
+		log.Errorf("Error on get Devices :%+s", err)
+		return
+	}
+	ctx.JSON(200, &devcfgarray)
+	log.Debugf("Getting DEVICEs %+v", &devcfgarray)
+}
+
+// AddEndpoint Insert new snmpdevice to de internal BBDD --pending--
+func AddEndpoint(ctx *Context, dev config.EndpointCfg) {
+	log.Printf("ADDING DEVICE %+v", dev)
+	affected, err := agent.MainConfig.Database.AddEndpointCfg(&dev)
+	if err != nil {
+		log.Warningf("Error on insert for device %s  , affected : %+v , error: %s", dev.ID, affected, err)
+		ctx.JSON(404, err.Error())
+	} else {
+		//TODO: review if needed return data  or affected
+		ctx.JSON(200, &dev)
+	}
+}
+
+// UpdateEndpoint --pending--
+func UpdateEndpoint(ctx *Context, dev config.EndpointCfg) {
+	id := ctx.Params(":id")
+	log.Debugf("Trying to update: %+v", dev)
+	affected, err := agent.MainConfig.Database.UpdateEndpointCfg(id, &dev)
+	if err != nil {
+		log.Warningf("Error on update for device %s  , affected : %+v , error: %s", dev.ID, affected, err)
+		ctx.JSON(404, err.Error())
+	} else {
+		//TODO: review if needed return device data
+		ctx.JSON(200, &dev)
+	}
+}
+
+//DeleteEndpoint removes and output backend
+func DeleteEndpoint(ctx *Context) {
+	id := ctx.Params(":id")
+	log.Debugf("Trying to delete: %+v", id)
+	affected, err := agent.MainConfig.Database.DelEndpointCfg(id)
+	if err != nil {
+		log.Warningf("Error on delete1 for device %s  , affected : %+v , error: %s", id, affected, err)
+		ctx.JSON(404, err.Error())
+	} else {
+		ctx.JSON(200, "deleted")
+	}
+}
+
+//GetEndpointCfgByID --pending--
+func GetEndpointCfgByID(ctx *Context) {
+	id := ctx.Params(":id")
+	dev, err := agent.MainConfig.Database.GetEndpointCfgByID(id)
+	if err != nil {
+		log.Warningf("Error on get Device  for device %s  , error: %s", id, err)
+		ctx.JSON(404, err.Error())
+	} else {
+		ctx.JSON(200, &dev)
+	}
+}
+
+//GetEndpointAffectOnDel --pending--
+func GetEndpointAffectOnDel(ctx *Context) {
+	id := ctx.Params(":id")
+	obarray, err := agent.MainConfig.Database.GetEndpointCfgAffectOnDel(id)
+	if err != nil {
+		log.Warningf("Error on get object array for SNMP metrics %s  , error: %s", id, err)
+		ctx.JSON(404, err.Error())
+	} else {
+		ctx.JSON(200, &obarray)
+	}
+}

--- a/pkg/webui/webserver.go
+++ b/pkg/webui/webserver.go
@@ -186,7 +186,7 @@ func WebServer(publicPath string, httpPort int, cfg *config.HTTPConfig, id strin
 	//Servers
 	NewAPICfgKapacitor(m)      //Kapacitor URL's
 	NewAPICfgIfxMeasurement(m) //Influx Measurments
-	NewAPICfgOutHTTP(m)        //HttpOut list
+	NewAPICfgEndpoint(m)        //Endpoint list
 	//Config
 
 	NewAPICfgAlertID(m)      //Alert Admin

--- a/src/app/alert/alert.component.html
+++ b/src/app/alert/alert.component.html
@@ -94,12 +94,12 @@
 
         <div class="well well-sm">
           <span class="editsection">External Services Settings</span>
-          <div class="form-group" style="margin-top: 25px" *ngIf="sampleComponentForm.controls.OutHTTP">
-            <label class="control-label col-sm-2" for="OutHTTP">Alerting Endpoints</label>
+          <div class="form-group" style="margin-top: 25px" *ngIf="sampleComponentForm.controls.Endpoint">
+            <label class="control-label col-sm-2" for="Endpoint">Alerting Endpoints</label>
             <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="List of EndPoints where the alert will be sent"></i>
             <div class="col-sm-9">
-              <ss-multiselect-dropdown [options]="select_outhttp" formControlName="OutHTTP" [texts]="myTexts" [ngModel]="sampleComponentForm.value.OutHTTP"></ss-multiselect-dropdown>
-              <control-messages [control]="sampleComponentForm.controls.OutHTTP"></control-messages>
+              <ss-multiselect-dropdown [options]="select_endpoint" formControlName="Endpoint" [texts]="myTexts" [ngModel]="sampleComponentForm.value.Endpoint"></ss-multiselect-dropdown>
+              <control-messages [control]="sampleComponentForm.controls.Endpoint"></control-messages>
             </div>
           </div>
 

--- a/src/app/alert/alert.component.ts
+++ b/src/app/alert/alert.component.ts
@@ -5,7 +5,7 @@ import { FormArray, FormGroup, FormControl} from '@angular/forms';
 import { AlertService } from './alert.service';
 import { ProductService } from '../product/product.service';
 import { RangeTimeService } from '../rangetime/rangetime.service';
-import { OutHTTPService } from '../outhttp/outhttp.service';
+import { EndpointService } from '../endpoint/endpoint.service';
 import { KapacitorService } from '../kapacitor/kapacitor.service';
 import { IfxDBService } from '../ifxdb/ifxdb.service';
 import { IfxMeasurementService } from '../ifxmeasurement/ifxmeasurement.service';
@@ -27,7 +27,7 @@ declare var _:any;
 
 @Component({
   selector: 'alert-component',
-  providers: [AlertService, ProductService, RangeTimeService, OutHTTPService, KapacitorService, IfxDBService,IfxMeasurementService, ValidationService],
+  providers: [AlertService, ProductService, RangeTimeService, EndpointService, KapacitorService, IfxDBService,IfxMeasurementService, ValidationService],
   templateUrl: './alert.component.html',
   styleUrls: ['../../css/component-styles.css']
 })
@@ -52,7 +52,7 @@ export class AlertComponent implements OnInit {
 
   public select_product : IMultiSelectOption[] = [];
   public select_rangetime : IMultiSelectOption[] = [];
-  public select_outhttp : IMultiSelectOption[] = [];
+  public select_endpoint : IMultiSelectOption[] = [];
   public select_kapacitor : IMultiSelectOption[] = [];
   public select_ifxdb : IMultiSelectOption[] = [];
   public select_ifxrp : IMultiSelectOption[] = [];
@@ -85,7 +85,7 @@ export class AlertComponent implements OnInit {
     this.reloadData();
   }
 
-  constructor(public alertService: AlertService,public productService :ProductService, public rangetimeService : RangeTimeService, public ifxDBService : IfxDBService, public ifxMeasurementService : IfxMeasurementService, public outhttpService: OutHTTPService, public kapacitorService: KapacitorService, public exportServiceCfg : ExportServiceCfg, builder: FormBuilder) {
+  constructor(public alertService: AlertService,public productService :ProductService, public rangetimeService : RangeTimeService, public ifxDBService : IfxDBService, public ifxMeasurementService : IfxMeasurementService, public endpointService: EndpointService, public kapacitorService: KapacitorService, public exportServiceCfg : ExportServiceCfg, builder: FormBuilder) {
     this.builder = builder;
   }
 
@@ -118,7 +118,7 @@ export class AlertComponent implements OnInit {
       ExtraLabel: [this.sampleComponentForm ? this.sampleComponentForm.value.ExtraLabel : ''],
       AlertExtraText: [this.sampleComponentForm ? this.sampleComponentForm.value.AlertExtraText : ''],
       KapacitorID: [this.sampleComponentForm ? this.sampleComponentForm.value.KapacitorID : '', Validators.required],
-      OutHTTP: [this.sampleComponentForm ? this.sampleComponentForm.value.OutHTTP : ''],
+      Endpoint: [this.sampleComponentForm ? this.sampleComponentForm.value.Endpoint : ''],
       Description: [this.sampleComponentForm ? this.sampleComponentForm.value.Description : '']
     });
   }
@@ -308,7 +308,7 @@ export class AlertComponent implements OnInit {
     //Check for subhidden fields
     this.getProductItem();
     this.getRangeTimeItem();
-    this.getOutHTTPItem();
+    this.getEndpointItem();
     this.getKapacitorItem();
     if (this.sampleComponentForm) {
       this.setDynamicFields(this.sampleComponentForm.value.TriggerType);
@@ -322,7 +322,7 @@ export class AlertComponent implements OnInit {
     let id = row.ID;
     this.getProductItem();
     this.getRangeTimeItem();
-    this.getOutHTTPItem();
+    this.getEndpointItem();
     this.getKapacitorItem();
     this.alertService.getAlertItemById(id)
       .subscribe(data => {
@@ -469,12 +469,12 @@ export class AlertComponent implements OnInit {
       );
   }
 
-  getOutHTTPItem() {
-    this.outhttpService.getOutHTTPItem(null)
+  getEndpointItem() {
+    this.endpointService.getEndpointItem(null)
       .subscribe(
       data => {
-        this.select_outhttp = [];
-        this.select_outhttp = this.createMultiselectArray(data, 'ID','ID');
+        this.select_endpoint = [];
+        this.select_endpoint = this.createMultiselectArray(data, 'ID','ID');
       },
       err => console.error(err),
       () => console.log('DONE')

--- a/src/app/alert/alert.data.ts
+++ b/src/app/alert/alert.data.ts
@@ -45,7 +45,7 @@ export const AlertComponentConfig: any =
       { 'title': 'ExtraLabel', 'name': 'ExtraLabel' },
       { 'title': 'AlertExtraText', 'name': 'AlertExtraText' },
       { 'title': 'KapacitorID', 'name': 'KapacitorID' },
-      { 'title': 'OutHTTP', 'name': 'OutHTTP' }
+      { 'title': 'Endpoint', 'name': 'Endpoint' }
     ],
     'slug' : 'alertcfg'
   };

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -63,7 +63,7 @@ import { IfxMeasurementComponent } from './ifxmeasurement/ifxmeasurement.compone
 import { ProductComponent } from './product/product.component';
 import { ProductGroupComponent } from './productgroup/productgroup.component';
 import { TemplateComponent } from './template/template.component';
-import { OutHTTPComponent } from './outhttp/outhttp.component';
+import { EndpointComponent } from './endpoint/endpoint.component';
 import { AlertComponent } from './alert/alert.component';
 import { AlertEventComponent } from './alertevent/alertevent.component';
 import { DeviceStatComponent } from './devicestat/devicestat.component';
@@ -93,7 +93,7 @@ import { DeviceStatComponent } from './devicestat/devicestat.component';
     ProductComponent,
     ProductGroupComponent,
     TemplateComponent,
-    OutHTTPComponent,
+    EndpointComponent,
     AlertComponent,
     AlertEventComponent,
     DeviceStatComponent,
@@ -139,7 +139,7 @@ import { DeviceStatComponent } from './devicestat/devicestat.component';
       ProductComponent,
       ProductGroupComponent,
       TemplateComponent,
-      OutHTTPComponent,
+      EndpointComponent,
       AlertComponent,
       AlertEventComponent,
       DeviceStatComponent

--- a/src/app/common/dataservice/export-file-modal.ts
+++ b/src/app/common/dataservice/export-file-modal.ts
@@ -10,7 +10,7 @@ import { IfxServerService } from '../../ifxserver/ifxserver.service';
 import { AlertService } from '../../alert/alert.service';
 import { DeviceStatService } from '../../devicestat/devicestat.service';
 import { KapacitorService } from '../../kapacitor/kapacitor.service';
-import { OutHTTPService } from '../../outhttp/outhttp.service';
+import { EndpointService } from '../../endpoint/endpoint.service';
 import { ProductService } from '../../product/product.service';
 import { ProductGroupService } from '../../productgroup/productgroup.service';
 import { RangeTimeService } from '../../rangetime/rangetime.service';
@@ -150,7 +150,7 @@ import { Subscription } from 'rxjs';
           </div>
         </div>`,
         styleUrls: ['./import-modal-styles.css'],
-        providers: [IfxServerService,AlertService,DeviceStatService,KapacitorService ,OutHTTPService ,ProductService,ProductGroupService,RangeTimeService ,TemplateService, TreeView]
+        providers: [IfxServerService,AlertService,DeviceStatService,KapacitorService ,EndpointService ,ProductService,ProductGroupService,RangeTimeService ,TemplateService, TreeView]
 })
 
 export class ExportFileModal {
@@ -176,7 +176,7 @@ export class ExportFileModal {
   constructor(builder: FormBuilder, public exportServiceCfg : ExportServiceCfg,
     public alertService : AlertService, public ifxServerService : IfxServerService, 
     public deviceStatService : DeviceStatService, public kapacitorService : KapacitorService,
-    public outHTTPService : OutHTTPService,public productService : ProductService, 
+    public endpointService : EndpointService,public productService : ProductService, 
     public productGroupService : ProductGroupService, public rangeTimeService : RangeTimeService,
     public templateService : TemplateService) {
 
@@ -203,7 +203,7 @@ export class ExportFileModal {
     "devicestatcfg": 'info',
     "ifxservercfg": 'success',
     "kapacitorcfg": 'primary',
-    "outhttpcfg": 'default',
+    "endpointcfg": 'default',
     "productcfg": 'warning',
     "productgroupcfg": 'info',
     "rangetimecfg": 'danger',
@@ -238,7 +238,7 @@ export class ExportFileModal {
     {'Type':"devicestatcfg", 'Class': 'info', 'Visible':false},
     {'Type':"ifxservercfg", 'Class' : 'success', 'Visible':false},
     {'Type':"kapacitorcfg", 'Class' : 'primary', 'Visible':false},
-    {'Type':"outhttpcfg", 'Class' : 'default', 'Visible':false},
+    {'Type':"endpointcfg", 'Class' : 'default', 'Visible':false},
     {'Type':"productcfg", 'Class' : 'warning', 'Visible':false},
     {'Type':"productgroupcfg", 'Class' : 'info', 'Visible':false},
     {'Type':"rangetimecfg", 'Class' : 'danger', 'Visible':false},
@@ -466,8 +466,8 @@ export class ExportFileModal {
        () => {console.log("DONE")}
        );
       break;
-      case 'outhttpcfg':
-      this.mySubscriber = this.outHTTPService.getOutHTTPItem(filter)
+      case 'endpointcfg':
+      this.mySubscriber = this.endpointService.getEndpointItem(filter)
        .subscribe(
        data => {
          this.dataArray=data;

--- a/src/app/common/dataservice/treeview.ts
+++ b/src/app/common/dataservice/treeview.ts
@@ -59,7 +59,7 @@ export class TreeView {
     "devicestatcfg": 'info',
     "ifxservercfg": 'success',
     "kapacitorcfg": 'primary',
-    "outhttpcfg": 'default',
+    "endpointcfg": 'default',
     "productcfg": 'warning',
     "productgroupcfg": 'info',
     "rangetimecfg": 'danger',

--- a/src/app/common/table-available-actions.ts
+++ b/src/app/common/table-available-actions.ts
@@ -18,8 +18,8 @@ export class AvailableTableActions {
         return this.getAlertEventAvailableActions();
         case 'devicestats-component':
         return this.getDeviceStatsAvailableActions();
-        case 'outhttp-component':
-        return this.getOutHTTPAvailableActions();
+        case 'endpoint-component':
+        return this.getEndpointAvailableActions();
         case 'product-component':
         return this.getProductAvailableActions();
         case 'rangetime-component':
@@ -74,7 +74,7 @@ export class AvailableTableActions {
     ];
     return tableAvailableActions;
   }
-  getOutHTTPAvailableActions (data ? : any) : any {
+  getEndpointAvailableActions (data ? : any) : any {
     let tableAvailableActions = [
     //Remove Action
       {'title': 'Remove', 'content' :

--- a/src/app/endpoint/endpoint.component.html
+++ b/src/app/endpoint/endpoint.component.html
@@ -1,0 +1,211 @@
+<h2>{{defaultConfig.name}}</h2>
+<hr>
+<ng-container [ngSwitch]="editmode">
+  <ng-template ngSwitchCase="list">
+    <test-modal #viewModal [titleName]="defaultConfig.name"></test-modal>
+    <test-modal #viewModalDelete titleName='Deleting:' [customMessage]="['Deleting this Endpoint Wrapper will affect the following components','Deleting this Endpoint Wrapper will NOT affect any component. Safe delete']" [customMessageClass]="['alert alert-danger','alert alert-success']"
+        [showValidation]="true" [textValidation]="'Delete'" [controlSize]="true" (validationClicked)="deleteSampleItem($event)">
+    </test-modal>
+    <export-file-modal #exportFileModal [showValidation]="true" [exportType]="defaultConfig['slug']" [textValidation]="'Export'" titleName='Exporting:'></export-file-modal>
+    <table-list #listTableComponent [typeComponent]="'endpoint-component'" [data]="data" [columns]="defaultConfig['table-columns']" [counterItems]="counterItems" [counterErrors]="counterErrors" [selectedArray]="selectedArray" [isRequesting]="isRequesting"
+        [tableRole]="tableRole" [roleActions]="overrideRoleActions" (customClicked)="customActions($event)"></table-list>
+  </ng-template>
+  <ng-template ngSwitchDefault>
+    <form [formGroup]="sampleComponentForm" class="form-horizontal" (ngSubmit)="editmode == 'create' ? saveSampleItem() : updateSampleItem()">
+      <ng-container>
+        <div class="row well well-sm">
+          <h4 style="display:inline"><i class="glyphicon glyphicon-cog text-info"></i> {{ editmode | uppercase}}</h4>
+          <div class="pull-right" style="margin-right: 20px">
+            <div style="display:inline" tooltip='Submit' container=body>
+              <button class="btn btn-success" type="submit" [disabled]="!sampleComponentForm.valid"> <i class="glyphicon glyphicon-ok-circle"></i></button>
+            </div>
+            <div style="display:inline" tooltip='Reset' container=body>
+              <button class="btn btn-warning" type="reset" [disabled]="!sampleComponentForm.dirty"><i class="glyphicon glyphicon-ban-circle"></i> </button>
+            </div>
+            <div style="display:inline" tooltip='Cancel' container=body>
+              <button class="btn btn-danger" type="button" (click)="cancelEdit()"><i class="glyphicon glyphicon-remove-circle"></i></button>
+            </div>
+          </div>
+        </div>
+      </ng-container>
+      <div class="form-fixed-height">
+        <div class="well well-sm">
+          <span class="editsection">Core Settings</span>
+          <div class="form-group" style="margin-top: 25px">
+            <label class="control-label col-sm-2" for="ID">ID</label>
+            <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Unique identifier of the Alerting Endpoint"></i>
+            <div class="col-sm-9">
+              <input formControlName="ID" id="ID" [ngModel]="sampleComponentForm.value.ID" />
+              <control-messages [control]="sampleComponentForm.controls.ID"></control-messages>
+            </div>
+          </div>
+          <div class="form-group">
+            <label class="control-label col-sm-2" for="Type">Type</label>
+            <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Type for the Alerting Endpoint"></i>
+            <div class="col-sm-9">
+              <select formControlName="Type" id="Type" (click)="setDynamicFields(sampleComponentForm.value.Type)" [ngModel]="sampleComponentForm.value.Type">
+                <option value="httppost" selected="selected">httppost</option>
+                <option value="logging">logging</option>
+                <option value="slack">slack</option>
+              </select>
+              <control-messages [control]="sampleComponentForm.controls.Type"></control-messages>
+            </div>
+          </div>
+        </div>
+        <div class="well well-sm">
+          <span class="editsection">Endpoint Settings</span>
+          <div *ngIf="sampleComponentForm.value.Type==='httppost'">
+            <div class="form-group" style="margin-top: 25px" *ngIf="sampleComponentForm.controls.URL">
+              <label class="control-label col-sm-2" for="URL">URL</label>
+              <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="URL for the HTTP POST"></i>
+              <div class="col-sm-9">
+                <input formControlName="URL" id="URL" [ngModel]="sampleComponentForm.value.URL" />
+                <control-messages [control]="sampleComponentForm.controls.URL"></control-messages>
+              </div>
+            </div>
+            <div class="form-group" *ngIf="sampleComponentForm.controls.Headers">
+              <label class="control-label col-sm-2" for="Headers">Headers</label>
+              <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Headers for the HTTP POST"></i>
+              <div class="col-sm-9">
+                <input formControlName="Headers" id="Headers" [ngModel]="sampleComponentForm.value.Headers" />
+                <control-messages [control]="sampleComponentForm.controls.Headers"></control-messages>
+              </div>
+            </div>
+            <div class="form-group" *ngIf="sampleComponentForm.controls.BasicAuthUsername">
+              <label class="control-label col-sm-2" for="BasicAuthUsername">BasicAuthUsername</label>
+              <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Username of BasicAuth for the HTTP POST"></i>
+              <div class="col-sm-9">
+                <input formControlName="BasicAuthUsername" id="BasicAuthUsername" [ngModel]="sampleComponentForm.value.BasicAuthUsername" />
+                <control-messages [control]="sampleComponentForm.controls.BasicAuthUsername"></control-messages>
+              </div>
+            </div>
+            <div class="form-group" *ngIf="sampleComponentForm.controls.BasicAuthPassword">
+              <label class="control-label col-sm-2" for="BasicAuthPassword">BasicAuthPassword</label>
+              <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Password of BasicAuth for the HTTP POST"></i>
+              <div class="col-sm-9">
+                <input type="password" formControlName="BasicAuthPassword" id="BasicAuthPassword" [ngModel]="sampleComponentForm.value.BasicAuthPassword" />
+                <control-messages [control]="sampleComponentForm.controls.BasicAuthPassword"></control-messages>
+              </div>
+            </div>
+          </div>
+          <div *ngIf="sampleComponentForm.value.Type==='logging'">
+            <div class="form-group" style="margin-top: 25px" *ngIf="sampleComponentForm.controls.LogFile">
+              <label class="control-label col-sm-2" for="LogFile">LogFile</label>
+              <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Path for the log file (absolute or relative)"></i>
+              <div class="col-sm-9">
+                <input formControlName="LogFile" id="LogFile" [ngModel]="sampleComponentForm.value.LogFile" />
+                <control-messages [control]="sampleComponentForm.controls.LogFile"></control-messages>
+              </div>
+            </div>
+            <div class="form-group" *ngIf="sampleComponentForm.controls.LogLevel">
+              <label class="control-label col-sm-2" for="LogLevel">LogLevel</label>
+              <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Value of the log level"></i>
+              <div class="col-sm-9">
+                <select formControlName="LogLevel" id="LogLevel" [ngModel]="sampleComponentForm.value.LogLevel">
+                  <option value="debug" selected="selected">debug</option>
+                  <option value="info">info</option>
+                  <option value="warning">warning</option>
+                  <option value="error">error</option>
+                  <option value="fatal">fatal</option>
+                  <option value="panic">panic</option>
+                </select>
+                <control-messages [control]="sampleComponentForm.controls.LogLevel"></control-messages>
+              </div>
+            </div>
+          </div>
+          <div *ngIf="sampleComponentForm.value.Type==='slack'">
+            <div class="form-group" style="margin-top: 25px" *ngIf="sampleComponentForm.controls.SlackEnabled">
+              <label class="control-label col-sm-2" for="SlackEnabled">SlackEnabled</label>
+              <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Indicates if Slack integration is enabled or not"></i>
+              <div class="col-sm-9">
+                <select formControlName="SlackEnabled" id="SlackEnabled" [ngModel]="sampleComponentForm.value.SlackEnabled">
+                  <option value="true">True</option>
+                  <option value="false" selected="selected">False</option>
+                </select>
+                <control-messages [control]="sampleComponentForm.controls.SlackEnabled"></control-messages>
+              </div>
+            </div>
+            <div class="form-group" *ngIf="sampleComponentForm.controls.URL">
+              <label class="control-label col-sm-2" for="URL">URL</label>
+              <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="The Slack webhook URL, can be obtained by adding Incoming Webhook integration"></i>
+              <div class="col-sm-9">
+                <input formControlName="URL" id="URL" [ngModel]="sampleComponentForm.value.URL" />
+                <control-messages [control]="sampleComponentForm.controls.URL"></control-messages>
+              </div>
+            </div>
+            <div class="form-group" *ngIf="sampleComponentForm.controls.Channel">
+              <label class="control-label col-sm-2" for="Channel">Channel</label>
+              <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="The Slack channel"></i>
+              <div class="col-sm-9">
+                <input formControlName="Channel" id="Channel" [ngModel]="sampleComponentForm.value.Channel" />
+                <control-messages [control]="sampleComponentForm.controls.Channel"></control-messages>
+              </div>
+            </div>
+            <div class="form-group" *ngIf="sampleComponentForm.controls.SlackUsername">
+              <label class="control-label col-sm-2" for="SlackUsername">SlackUsername</label>
+              <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="The username of the Slack bot"></i>
+              <div class="col-sm-9">
+                <input formControlName="SlackUsername" id="SlackUsername" [ngModel]="sampleComponentForm.value.SlackUsername" />
+                <control-messages [control]="sampleComponentForm.controls.SlackUsername"></control-messages>
+              </div>
+            </div>
+            <div class="form-group" *ngIf="sampleComponentForm.controls.IconEmoji">
+              <label class="control-label col-sm-2" for="IconEmoji">IconEmoji</label>
+              <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="IconEmoji uses an emoji instead of the normal icon for the message. The contents should be the name of an emoji surrounded with ':', i.e. ':chart_with_upwards_trend:'"></i>
+              <div class="col-sm-9">
+                <input formControlName="IconEmoji" id="IconEmoji" [ngModel]="sampleComponentForm.value.IconEmoji" />
+                <control-messages [control]="sampleComponentForm.controls.IconEmoji"></control-messages>
+              </div>
+            </div>
+            <div class="form-group" *ngIf="sampleComponentForm.controls.SslCa">
+              <label class="control-label col-sm-2" for="SslCa">SslCa</label>
+              <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Path to CA file"></i>
+              <div class="col-sm-9">
+                <input formControlName="SslCa" id="SslCa" [ngModel]="sampleComponentForm.value.SslCa" />
+                <control-messages [control]="sampleComponentForm.controls.SslCa"></control-messages>
+              </div>
+            </div>
+            <div class="form-group" *ngIf="sampleComponentForm.controls.SslCert">
+              <label class="control-label col-sm-2" for="SslCert">SslCert</label>
+              <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Path to host cert file"></i>
+              <div class="col-sm-9">
+                <input formControlName="SslCert" id="SslCert" [ngModel]="sampleComponentForm.value.SslCert" />
+                <control-messages [control]="sampleComponentForm.controls.SslCert"></control-messages>
+              </div>
+            </div>
+            <div class="form-group" *ngIf="sampleComponentForm.controls.SslKey">
+              <label class="control-label col-sm-2" for="SslKey">SslKey</label>
+              <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Path to cert key file"></i>
+              <div class="col-sm-9">
+                <input formControlName="SslKey" id="SslKey" [ngModel]="sampleComponentForm.value.SslKey" />
+                <control-messages [control]="sampleComponentForm.controls.SslKey"></control-messages>
+              </div>
+            </div>
+            <div class="form-group" *ngIf="sampleComponentForm.controls.InsecureSkipVerify">
+              <label class="control-label col-sm-2" for="InsecureSkipVerify">InsecureSkipVerify</label>
+              <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Use SSL but skip chain & host verification"></i>
+              <div class="col-sm-9">
+                <select formControlName="InsecureSkipVerify" id="InsecureSkipVerify" [ngModel]="sampleComponentForm.value.InsecureSkipVerify">
+                  <option value="true">True</option>
+                  <option value="false" selected="selected">False</option>
+                </select>
+                <control-messages [control]="sampleComponentForm.controls.InsecureSkipVerify"></control-messages>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="well well-sm">
+          <span class="editsection">Extra Settings</span>
+          <div class="form-group" style="margin-top: 25px">
+            <label class="control-label col-sm-2" for="Description">Description</label>
+            <i placement="top" style="float: left" class="info control-label glyphicon glyphicon-info-sign" tooltipAnimation="true" tooltip="Description of the Alerting Endpoint"></i>
+            <div class="col-sm-9">
+              <textarea class="form-control" style="width: 50%" rows="2" formControlName="Description" id="Description" [ngModel]="sampleComponentForm.value.Description"> </textarea>
+              <control-messages [control]="sampleComponentForm.controls.Description"></control-messages>
+            </div>
+          </div>
+        </div>
+      </div>
+    </form>
+  </ng-template>
+</ng-container>

--- a/src/app/endpoint/endpoint.component.ts
+++ b/src/app/endpoint/endpoint.component.ts
@@ -1,0 +1,340 @@
+import { Component, ChangeDetectionStrategy, ViewChild, OnInit } from '@angular/core';
+import { FormBuilder, Validators} from '@angular/forms';
+import { FormArray, FormGroup, FormControl} from '@angular/forms';
+
+import { EndpointService } from './endpoint.service';
+import { ValidationService } from '../common/custom-validation/validation.service'
+import { ExportServiceCfg } from '../common/dataservice/export.service'
+import { ExportFileModal } from '../common/dataservice/export-file-modal';
+
+import { GenericModal } from '../common/custom-modal/generic-modal';
+import { Observable } from 'rxjs/Rx';
+
+import { TableListComponent } from '../common/table-list.component';
+import { EndpointComponentConfig, TableRole, OverrideRoleActions } from './endpoint.data';
+
+declare var _:any;
+
+@Component({
+  selector: 'endpoint-component',
+  providers: [EndpointService, ValidationService],
+  templateUrl: './endpoint.component.html',
+  styleUrls: ['../../css/component-styles.css']
+})
+
+export class EndpointComponent implements OnInit {
+  @ViewChild('viewModal') public viewModal: GenericModal;
+  @ViewChild('viewModalDelete') public viewModalDelete: GenericModal;
+  @ViewChild('listTableComponent') public listTableComponent: TableListComponent;
+  @ViewChild('exportFileModal') public exportFileModal : ExportFileModal;
+
+
+  public editmode: string; //list , create, modify
+  public componentList: Array<any>;
+  public filter: string;
+  public sampleComponentForm: any;
+  public counterItems : number = null;
+  public counterErrors: any = [];
+  public defaultConfig : any = EndpointComponentConfig;
+  public tableRole : any = TableRole;
+  public overrideRoleActions: any = OverrideRoleActions;
+  public selectedArray : any = [];
+
+  public data : Array<any>;
+  public isRequesting : boolean;
+
+  private builder;
+  private oldID : string;
+
+  ngOnInit() {
+    this.editmode = 'list';
+    this.reloadData();
+  }
+
+  constructor(public endpointService: EndpointService, public exportServiceCfg : ExportServiceCfg, builder: FormBuilder) {
+    this.builder = builder;
+  }
+
+  createStaticForm() {
+    this.sampleComponentForm = this.builder.group({
+      ID: [this.sampleComponentForm ? this.sampleComponentForm.value.ID : '', Validators.required],
+      Type: [this.sampleComponentForm ? this.sampleComponentForm.value.Type : '', Validators.required],
+      Description: [this.sampleComponentForm ? this.sampleComponentForm.value.Description : '']
+    });
+  }
+
+  createDynamicForm(fieldsArray: any) : void {
+
+    //Generates the static form:
+    //Saves the actual to check later if there are shared values
+    let tmpform : any;
+    if (this.sampleComponentForm)  tmpform = this.sampleComponentForm.value;
+    this.createStaticForm();
+    //Set new values and check if we have to mantain the value!
+    for (let entry of fieldsArray) {
+      let value = entry.defVal;
+      //Check if there are common values from the previous selected item
+      if (tmpform) {
+        if (tmpform[entry.ID] !== null && entry.override !== true) {
+          value = tmpform[entry.ID];
+        }
+      }
+      //Set different controls:
+      this.sampleComponentForm.addControl(entry.ID, new FormControl(value, entry.Validators));
+    }
+  }
+
+  setDynamicFields (field : any, override? : boolean) : void  {
+    //Saves on the array all values to push into formGroup
+    let controlArray : Array<any> = [];
+    switch (field) {
+      case 'httppost':
+      controlArray.push({'ID': 'URL', 'defVal' : '', 'Validators' : Validators.required });
+      controlArray.push({'ID': 'Headers', 'defVal' : '' });
+      controlArray.push({'ID': 'BasicAuthUsername', 'defVal' : '' });
+      controlArray.push({'ID': 'BasicAuthPassword', 'defVal' : '' });
+      break;
+      case 'logging':
+      controlArray.push({'ID': 'LogFile', 'defVal' : '', 'Validators' : Validators.required });
+      controlArray.push({'ID': 'LogLevel', 'defVal' : '', 'Validators' : Validators.required });
+      break;
+      case 'slack':
+      controlArray.push({'ID':'SlackEnabled','defVal' :'','Validators' : Validators.required });
+      controlArray.push({'ID':'URL','defVal' :'', 'Validators' : Validators.required });
+      controlArray.push({'ID':'Channel','defVal' :'','Validators' : Validators.required });
+      controlArray.push({'ID':'SlackUsername','defVal' :'','Validators' : Validators.required });
+      controlArray.push({'ID':'IconEmoji','defVal' :'' });
+      controlArray.push({'ID':'SslCa','defVal' :'' });
+      controlArray.push({'ID':'SslCert','defVal' :'' });
+      controlArray.push({'ID':'SslKey','defVal' :'' });
+      controlArray.push({'ID':'InsecureSkipVerify','defVal' :'' });
+      break;
+      default: //Default mode is httppost
+      controlArray.push({'ID': 'URL', 'defVal' : '', 'Validators' : Validators.required });
+      controlArray.push({'ID': 'Headers', 'defVal' : '' });
+      controlArray.push({'ID': 'BasicAuthUsername', 'defVal' : '' });
+      controlArray.push({'ID': 'BasicAuthPassword', 'defVal' : '' });
+      break;
+    }
+    //Reload the formGroup with new values saved on controlArray
+    this.createDynamicForm(controlArray);
+  }
+
+  reloadData() {
+    // now it's a simple subscription to the observable
+    this.endpointService.getEndpointItem(null)
+      .subscribe(
+      data => {
+        this.isRequesting = false;
+        this.componentList = data
+        this.data = data;
+        this.editmode = "list";
+      },
+      err => console.error(err),
+      () => console.log('DONE')
+      );
+  }
+
+  customActions(action : any) {
+    switch (action.option) {
+      case 'new' :
+        this.newItem();
+      break;
+      case 'export' :
+        this.exportItem(action.event);
+      break;
+      case 'view':
+        this.viewItem(action.event);
+      break;
+      case 'edit':
+        this.editSampleItem(action.event);
+      break;
+      case 'remove':
+        this.removeItem(action.event);
+      break;
+      case 'tableaction':
+        this.applyAction(action.event, action.data);
+      break;
+    }
+  }
+
+
+  applyAction(action : any, data? : Array<any>) : void {
+    this.selectedArray = data || [];
+    switch(action.action) {
+       case "RemoveAllSelected": {
+          this.removeAllSelectedItems(this.selectedArray);
+          break;
+       }
+       case "ChangeProperty": {
+          this.updateAllSelectedItems(this.selectedArray,action.field,action.value)
+          break;
+       }
+       case "AppendProperty": {
+         this.updateAllSelectedItems(this.selectedArray,action.field,action.value,true);
+       }
+       default: {
+          break;
+       }
+    }
+  }
+
+  viewItem(id) {
+    this.viewModal.parseObject(id);
+  }
+
+  exportItem(item : any) : void {
+    this.exportFileModal.initExportModal(item);
+  }
+
+  removeAllSelectedItems(myArray) {
+    let obsArray = [];
+    this.counterItems = 0;
+    this.isRequesting = true;
+    for (let i in myArray) {
+      console.log("Removing ",myArray[i].ID)
+      this.deleteSampleItem(myArray[i].ID,true);
+      obsArray.push(this.deleteSampleItem(myArray[i].ID,true));
+    }
+    this.genericForkJoin(obsArray);
+  }
+
+  removeItem(row) {
+    let id = row.ID;
+    console.log('remove', id);
+    this.endpointService.checkOnDeleteEndpointItem(id)
+      .subscribe(
+        data => {
+        this.viewModalDelete.parseObject(data)
+      },
+      err => console.error(err),
+      () => { }
+      );
+  }
+  newItem() {
+    if (this.sampleComponentForm) {
+      this.setDynamicFields(this.sampleComponentForm.value.Type);
+    } else {
+      this.setDynamicFields(null);
+    }
+    this.editmode = "create";
+  }
+
+  editSampleItem(row) {
+    let id = row.ID;
+    this.endpointService.getEndpointItemById(id)
+      .subscribe(data => {
+        this.sampleComponentForm = {};
+        this.sampleComponentForm.value = data;
+        this.oldID = data.ID;
+        this.setDynamicFields(data.Type);
+        this.editmode = "modify";
+      },
+      err => console.error(err)
+      );
+ 	}
+
+  deleteSampleItem(id, recursive?) {
+    if (!recursive) {
+    this.endpointService.deleteEndpointItem(id)
+      .subscribe(data => { },
+      err => console.error(err),
+      () => { this.viewModalDelete.hide(); this.reloadData() }
+      );
+    } else {
+      return this.endpointService.deleteEndpointItem(id)
+      .do(
+        (test) =>  { this.counterItems++; console.log(this.counterItems)},
+        (err) => { this.counterErrors.push({'ID': id, 'error' : err})}
+      );
+    }
+  }
+
+  cancelEdit() {
+    this.editmode = "list";
+    this.reloadData();
+  }
+
+  saveSampleItem() {
+    if (this.sampleComponentForm.valid) {
+      this.endpointService.addEndpointItem(this.sampleComponentForm.value)
+        .subscribe(data => { console.log(data) },
+        err => {
+          console.log(err);
+        },
+        () => { this.editmode = "list"; this.reloadData() }
+        );
+    }
+  }
+
+  updateAllSelectedItems(mySelectedArray,field,value, append?) {
+    let obsArray = [];
+    this.counterItems = 0;
+    this.isRequesting = true;
+    if (!append)
+    for (let component of mySelectedArray) {
+      component[field] = value;
+      obsArray.push(this.updateSampleItem(true,component));
+    } else {
+      let tmpArray = [];
+      if(!Array.isArray(value)) value = value.split(',');
+      for (let component of mySelectedArray) {
+        //check if there is some new object to append
+        let newEntries = _.differenceWith(value,component[field],_.isEqual);
+        tmpArray = newEntries.concat(component[field])
+        component[field] = tmpArray;
+        obsArray.push(this.updateSampleItem(true,component));
+      }
+    }
+    this.genericForkJoin(obsArray);
+    //Make sync calls and wait the result
+    this.counterErrors = [];
+  }
+
+  updateSampleItem(recursive?, component?) {
+    if(!recursive) {
+      if (this.sampleComponentForm.valid) {
+        var r = true;
+        if (this.sampleComponentForm.value.ID != this.oldID) {
+          r = confirm("Changing Endpoint Instance ID from " + this.oldID + " to " + this.sampleComponentForm.value.ID + ". Proceed?");
+        }
+        if (r == true) {
+          this.endpointService.editEndpointItem(this.sampleComponentForm.value, this.oldID)
+            .subscribe(data => { console.log(data) },
+            err => console.error(err),
+            () => { this.editmode = "list"; this.reloadData() }
+            );
+        }
+      }
+    } else {
+      return this.endpointService.editEndpointItem(component, component.ID)
+      .do(
+        (test) =>  { this.counterItems++ },
+        (err) => { this.counterErrors.push({'ID': component['ID'], 'error' : err['_body']})}
+      )
+      .catch((err) => {
+        return Observable.of({'ID': component.ID , 'error': err['_body']})
+      })
+    }
+  }
+
+  genericForkJoin(obsArray: any) {
+    Observable.forkJoin(obsArray)
+              .subscribe(
+                data => {
+                  this.selectedArray = [];
+                  this.reloadData()
+                },
+                err => console.error(err),
+              );
+  }
+
+  createMultiselectArray(tempArray) : any {
+    let myarray = [];
+    for (let entry of tempArray) {
+      myarray.push({ 'id': entry.ID, 'name': entry.ID, 'extraData': entry.Description });
+    }
+    return myarray;
+  }
+
+}

--- a/src/app/endpoint/endpoint.data.ts
+++ b/src/app/endpoint/endpoint.data.ts
@@ -1,0 +1,21 @@
+export const EndpointComponentConfig: any =
+  {
+    'name' : 'Alerting Endpoints',
+    'table-columns' : [
+      { 'title': 'ID', 'name': 'ID' },
+      { 'title': 'Type', 'name': 'Type' },
+      { 'title': 'URL', 'name': 'URL' },
+      { 'title': 'SlackEnabled', 'name': 'SlackEnabled' },
+      { 'title': 'Channel', 'name': 'Channel' },
+      { 'title': 'LogFile', 'name': 'LogFile' },
+      { 'title': 'LogLevel', 'name': 'LogLevel' },
+    ],
+    'slug' : 'endpointcfg'
+  };
+  export const TableRole : string = 'fulledit';
+  export const OverrideRoleActions : Array<Object> = [
+    {'name':'export', 'type':'icon', 'icon' : 'glyphicon glyphicon-download-alt text-info', 'tooltip': 'Export item'},
+    {'name':'view', 'type':'icon', 'icon' : 'glyphicon glyphicon-eye-open text-success', 'tooltip': 'View item'},
+    {'name':'edit', 'type':'icon', 'icon' : 'glyphicon glyphicon-edit text-warning', 'tooltip': 'Edit item'},
+    {'name':'remove', 'type':'icon', 'icon' : 'glyphicon glyphicon glyphicon-remove text-danger', 'tooltip': 'Remove item'},
+  ]

--- a/src/app/endpoint/endpoint.service.ts
+++ b/src/app/endpoint/endpoint.service.ts
@@ -1,0 +1,75 @@
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs/Observable';
+import { HttpService } from '../core/http.service';
+
+declare var _:any;
+
+@Injectable()
+export class EndpointService {
+
+    constructor(private http: HttpService,) {
+    }
+
+    jsonParser(key,value) {
+        if ( key == 'Headers') {
+            if(typeof value === 'string') return value.split(',');
+        }
+        if ( key == 'SlackEnabled' || key == 'InsecureSkipVerify' ) {
+            return ( value === "true" || value === true);
+        }
+        return value;
+    }
+
+    addEndpointItem(dev) {
+        return this.http.post('/api/cfg/endpoint',JSON.stringify(dev,this.jsonParser))
+        .map( (responseData) => responseData.json());
+
+    }
+
+    editEndpointItem(dev, id) {
+        return this.http.put('/api/cfg/endpoint/'+id,JSON.stringify(dev,this.jsonParser))
+        .map( (responseData) => responseData.json());
+    }
+
+
+    getEndpointItem(filter_s: string) {
+        return this.http.get('/api/cfg/endpoint')
+        .map( (responseData) => {
+            return responseData.json();
+        })
+    }
+
+    getEndpointItemById(id : string) {
+        // return an observable
+        console.log("ID: ",id);
+        return this.http.get('/api/cfg/endpoint/'+id)
+        .map( (responseData) =>
+            responseData.json()
+    )};
+
+    checkOnDeleteEndpointItem(id : string){
+      return this.http.get('/api/cfg/endpoint/checkondel/'+id)
+      .map( (responseData) =>
+       responseData.json()
+      ).map((deleteobject) => {
+          console.log("MAP SERVICE",deleteobject);
+          let result : any = {'ID' : id};
+          _.forEach(deleteobject,function(value,key){
+              result[value.TypeDesc] = [];
+          });
+          _.forEach(deleteobject,function(value,key){
+              result[value.TypeDesc].Description=value.Action;
+              result[value.TypeDesc].push(value.ObID);
+          });
+          return result;
+      });
+    };
+
+    deleteEndpointItem(id : string) {
+        // return an observable
+        return this.http.delete('/api/cfg/endpoint/'+id)
+        .map( (responseData) =>
+         responseData.json()
+        );
+    };
+}

--- a/src/app/home/home.data.ts
+++ b/src/app/home/home.data.ts
@@ -8,7 +8,7 @@ import { RangeTimeComponent } from '../rangetime/rangetime.component';
 import { ProductComponent } from '../product/product.component';
 import { ProductGroupComponent } from '../productgroup/productgroup.component';
 import { TemplateComponent } from '../template/template.component';
-import { OutHTTPComponent } from '../outhttp/outhttp.component';
+import { EndpointComponent } from '../endpoint/endpoint.component';
 import { AlertComponent } from '../alert/alert.component';
 import { AlertEventComponent } from '../alertevent/alertevent.component';
 import { DeviceStatComponent } from '../devicestat/devicestat.component'
@@ -56,7 +56,7 @@ export const HomeComponentConfig: any =
     [
       {'title': 'Influx DB Servers ', 'selector' : 'ifxserver-component', 'type': 'component', 'data': IfxServerComponent},
       {'title': 'Kapacitor Backends', 'selector' : 'kapacitor-component', 'type': 'component', 'data': KapacitorComponent},
-      {'title': 'Alerting Endpoints', 'selector' : 'outhttp-component', 'type': 'component', 'data': OutHTTPComponent},
+      {'title': 'Alerting Endpoints', 'selector' : 'endpoint-component', 'type': 'component', 'data': EndpointComponent},
     ]
     }, 
     {'groupName' : 'Configuration', 'icon': 'glyphicon glyphicon-cog', 'expanded': true, 'items':


### PR DESCRIPTION
outhttp and similar changed to endpoint.
### breaking changes
* Table out_http_cfg changed to endpoint_cfg.
* Table alert_http_out_rel changed to alert_endpoint_rel.
* Execute the following sqls if you want to copy data from old tables to new tables:
    * insert into endpoint_cfg (id, type, description, url, headers, basicauthusername, basicauthpassword, logfile, loglevel, slackenabled, channel, slackusername, iconemoji, sslca, sslcert, sslkey, insecureskipverify) select id, type, description, url, headers, basicauthusername, basicauthpassword, logfile, loglevel, slackenabled, channel, slackusername, iconemoji, sslca, sslcert, sslkey, insecureskipverify from out_http_cfg;
	* insert into alert_endpoint_rel (alert_id, endpoint_id) select alert_id, http_out_id from alert_http_out_rel;
