### PR TITLE
Changes on AlertID column for Alert Events and Alert Events History

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # CHANGELOG.md
 
+## v 0.6.2  (31/10/2018)
+
+### New features.
+
+
+### fixes
+
+* Changes on Alert Events and Alert Events History components:
+  * AlertID column shows the ID of the Resistor Alert again, not the ID received from the Kapacitor AlertNode.
+
+### breaking changes
+
+
 ## v 0.6.1  (30/10/2018)
 
 ### New features.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "company": "Toni Inc"
   },
   "name": "resistor",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "repository": {
     "type": "git",
     "url": "http://github.com/toni-moreno/resistor.git"

--- a/pkg/webui/apirt-kapfilter.go
+++ b/pkg/webui/apirt-kapfilter.go
@@ -117,7 +117,7 @@ func makeAlertEvent(correlationID string, al alert.Data, alertcfg config.AlertID
 	alertevent := config.AlertEvent{}
 	alertevent.ID = 0
 	alertevent.CorrelationID = correlationID
-	alertevent.AlertID = al.ID
+	alertevent.AlertID = alertcfg.ID
 	alertevent.Message = al.Message
 	alertevent.Details = al.Details
 	if len(prevalevtarray) > 0 {


### PR DESCRIPTION
AlertID column shows the ID of the Resistor Alert again, not the ID received from the Kapacitor AlertNode.